### PR TITLE
Message Collector (non)blocking start functions

### DIFF
--- a/src/commands/guild/enable.ts
+++ b/src/commands/guild/enable.ts
@@ -19,6 +19,7 @@ export const enable = {
       ctx.reply(
         `Usage: ${ctx.prefix}enable [levels/mod logs/role edits/auto quotes/welcomes]`
       );
+      return;
     }
 
     let attr: string = '';
@@ -53,6 +54,8 @@ export const enable = {
         collector.on('end', () => {
           attr = `mod logs. You did not set a mod log channel. You can set one by doing ${ctx.prefix}set mod log channel #channel`;
         });
+
+        await collector.wait();
         break;
       case 'edits':
       case 'role edits':

--- a/src/commands/owner/steal.ts
+++ b/src/commands/owner/steal.ts
@@ -112,6 +112,8 @@ export const steal: CommandOptions = {
       collector.on('end', () => {
         ctx.reply('Why do you type so slow dude.');
       });
+
+      collector.start();
     } else {
       await createEmoji(ctx, emojis, r, 0, true);
     }

--- a/src/commands/profile/gamble.ts
+++ b/src/commands/profile/gamble.ts
@@ -79,5 +79,7 @@ export const gamble = {
     collector.on('end', () => {
       ctx.reply('You took too long, gamble cancelled!');
     });
+
+    collector.start();
   },
 };

--- a/src/commands/profile/mir.ts
+++ b/src/commands/profile/mir.ts
@@ -36,9 +36,10 @@ export const mir = {
         ctx.prefix
       }grab" gets to keep them!`
     );
-    let thing = new MessageCollector(ctx, 30000, filter);
-    thing.on('collect', (m: Message) => {
-      thing.destroy();
+
+    let collector = new MessageCollector(ctx, 30000, filter);
+    collector.on('collect', (m: Message) => {
+      collector.destroy();
       ctx.commandClient.query(
         `UPDATE users SET credits = credits + ${cr} WHERE user_id = ${
           m.member!.id
@@ -49,7 +50,7 @@ export const mir = {
       );
     });
 
-    thing.on('end', () => {
+    collector.on('end', () => {
       ctx.reply('It seems as if no one has picked up the credits. Oh well.');
       ctx.commandClient.query(
         `UPDATE users SET credits = credits + ${cr} WHERE user_id = ${
@@ -57,5 +58,7 @@ export const mir = {
         }`
       );
     });
+
+    collector.start();
   },
 };


### PR DESCRIPTION
This adds two new functions to MessageCollector

`start()` provides a non-blocking approach, for if you do not care if you get a result.
`wait()` provides a blocking approach, this will sit and wait until either timeout, or a verified message is returned.
**One of them MUST be called after instantiating a MessageCollector or it will not run**

All usages of MessageCollector were updated, the only blocking one is within the enable command for mod logs.