### PR TITLE
fix welcomes

### DIFF
--- a/src/commands/guild/enable.ts
+++ b/src/commands/guild/enable.ts
@@ -71,6 +71,7 @@ export const enable = {
       case 'welcomes':
       case 'welcome':
         ctx.guild!.flags |= GuildFlags.WELCOMES;
+        attr = 'welcome messages';
         break;
       default:
         break;

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -2,7 +2,7 @@ import { ClientEvents, AuditLogActions } from 'detritus-client/lib/constants';
 import { CommandClient, GatewayClientEvents } from 'detritus-client';
 import { DBServer } from '../modules/db';
 import { ModLogActions } from '../modules/modlog';
-import { AuditLog } from 'detritus-client/lib/structures';
+import { AuditLog, Guild, Member } from 'detritus-client/lib/structures';
 import { Page, GuildFlags } from '../modules/utils';
 
 export const guildMemberAdd = {
@@ -14,68 +14,73 @@ export const guildMemberAdd = {
     let member = payload.member;
     let guild = payload.member.guild!;
 
-    if (!guild.me?.canViewAuditLogs) return;
+    await client.checkGuild(payload.guildId)
 
-    await client.checkGuild(payload.guildId).then(async () => {
-      let server: DBServer = await client.queryOne(
-        `SELECT mod_channel, flags, welcome_message, welcome_channel, welcome_role FROM servers WHERE server_id = ${payload.guildId}`
-      );
+    let server: DBServer = await client.queryOne(
+      `SELECT mod_channel, flags, welcome_message, welcome_channel, welcome_role FROM servers WHERE server_id = ${payload.guildId}`
+    );
 
-      if (!server.mod_channel) return;
-
-      let channel = guild.channels.get(server.mod_channel.toString());
-      if (channel) {
-        if (
-          (ModLogActions.GUILD_MEMBER_ADD & guild.modLog) ===
-          ModLogActions.GUILD_MEMBER_ADD
-        ) {
-          if (member.bot) {
-            guild
-              .fetchAuditLogs({
-                actionType: AuditLogActions.BOT_ADD,
-              })
-              .then((audit) => {
-                channel!.createMessage({
-                  embed: makeEmbed(
-                    audit.find((v, _) => v.targetId === payload.userId)!,
-                    payload
-                  ),
-                });
-              })
-              .catch((error) => {
-                console.error(`GuildMemberAdd/${payload.guildId} ${error}`);
-              });
-          }
-        }
-      }
-
-      if (client.hasFlag(server.flags, GuildFlags.WELCOMES)) {
-        const channel = guild.channels.get(server.welcome_channel.toString());
-
-        if (channel) {
-          if (server.welcome_message) {
-            let unsyntaxed = server.welcome_message
-              .replace('{user}', member.username)
-              .replace('{guild}', guild.name);
-            channel.createMessage(unsyntaxed);
-          } else {
-            channel.createMessage(
-              `**${member.username}** just joined **${guild.name}**`
-            );
-          }
-        }
-
-        if (!server.welcome_role) return;
-
-        const role = guild.roles.get(server.welcome_role.toString());
-
-        if (role) {
-          await member.addRole(role.id);
-        }
-      }
-    });
+    await Promise.all([
+      maybeModLog(payload, member, guild, server),
+      maybeWelcome(client, member, guild, server)
+    ])
   },
 };
+
+async function maybeModLog(payload: GatewayClientEvents.GuildMemberAdd, member: Member, guild: Guild, server: DBServer) {
+  if (!server.mod_channel) return;
+  if (!guild.me?.canViewAuditLogs) return;
+
+  let channel = guild.channels.get(server.mod_channel.toString());
+  if (channel) {
+    if (
+      (ModLogActions.GUILD_MEMBER_ADD & guild.modLog) ===
+      ModLogActions.GUILD_MEMBER_ADD
+    ) {
+      if (member.bot) {
+        guild
+          .fetchAuditLogs({
+            actionType: AuditLogActions.BOT_ADD,
+          })
+          .then((audit) => {
+            channel!.createMessage({
+              embed: makeEmbed(
+                audit.find((v, _) => v.targetId === payload.userId)!,
+                payload
+              ),
+            });
+          })
+          .catch((error) => {
+            console.error(`GuildMemberAdd/${payload.guildId} ${error}`);
+          });
+      }
+    }
+  }
+}
+
+async function maybeWelcome(client: CommandClient, member: Member, guild: Guild, server: DBServer) {
+  if (!client.hasFlag(server.flags, GuildFlags.WELCOMES)) return;
+  const channel = guild.channels.get(server.welcome_channel.toString());
+
+  if (channel) {
+    if (server.welcome_message) {
+      let unsyntaxed = server.welcome_message
+        .replace('{user}', member.username)
+        .replace('{guild}', guild.name);
+      channel.createMessage(unsyntaxed);
+    } else {
+      channel.createMessage(
+        `**${member.username}** just joined **${guild.name}**`
+      );
+    }
+  }
+
+  if (!server.welcome_role) return;
+  const role = guild.roles.get(server.welcome_role.toString());
+  if (role) {
+    await member.addRole(role.id);
+  }
+}
 
 function makeEmbed(
   audit: AuditLog,


### PR DESCRIPTION
**these changes are completely untested, so merge if you tested this code (or you trust me 😘)**

- fixes `//guild enable welcomes` by setting an attr for the success message
- fixes welcoming by refactoring `guildMemberAdd` and moving mod log specific checks away from the welcoming code so it runs even when guild join mod logging fails